### PR TITLE
Fix issue when trying to opam install probzelus

### DIFF
--- a/probzelus/configure
+++ b/probzelus/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env ocaml -I +unix
+#!/usr/bin/env -S ocaml -I +unix
 
 #load "unix.cma"
 


### PR DESCRIPTION
When I tried to install probzelus with opam, I got this error message:
```
# /usr/bin/env: ‘ocaml -I +unix’: No such file or directory
# /usr/bin/env: use -[v]S to pass options in shebang lines
``` 

I have changed this and now there is no more error on my computer 